### PR TITLE
Added correct WebSocket API defaults for protocol.

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -46,6 +46,7 @@
  * - Joe Walnes
  */
 function ReconnectingWebSocket(url, protocols) {
+    protocols = protocols || [];
 
     // These can be altered by calling code.
     this.debug = false;


### PR DESCRIPTION
In the WebSocket API, if the second argument is omitted, it should default to an empty array (not undefined).

> The WebSocket(url, protocols) constructor takes one or two arguments. The first argument, url, specifies the URL to which to connect. The second, protocols, if present, is either a string or an array of strings. If it is a string, it is equivalent to an array consisting of just that string; if it is omitted, it is equivalent to the empty array.

This fix sets the default correctly in ReconnectingWebSocket.
