### PR TITLE
stop reconnecting after close() is called

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -155,8 +155,8 @@ function ReconnectingWebSocket(url, protocols) {
     };
 
     this.close = function() {
+        forcedClose = true;
         if (ws) {
-            forcedClose = true;
             ws.close();
         }
     };


### PR DESCRIPTION
If close() is called when the websocket connection is down it should not try to reconnect. There are at least two reasons to avoid this. It should not send a lot of unnecessary requests and if it is able to reconnect the connection will go live again even if the application using reconnecting-websocket tried to close it.
