### PR TITLE
Fix typo that passes url to connect

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -141,7 +141,7 @@ function ReconnectingWebSocket(url, protocols) {
             self.onerror(event);
         };
     }
-    connect(url);
+    connect(false);
 
     this.send = function(data) {
         if (ws) {


### PR DESCRIPTION
I think false should be passed to the initial connect call, not the URL. Didn't affect functionality.
