### PR TITLE
Provide package.json to make possible using library with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ReconnectingWebSocket",
+  "version": "0.0.0",
+  "description": "A small JavaScript library that decorates the WebSocket API to provide a WebSocket connection that will automatically reconnect if the connection is dropped.",
+  "main": "reconnecting-websocket.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joewalnes/reconnecting-websocket"
+  },
+  "author": "Joe Walnes",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/joewalnes/reconnecting-websocket/issues"
+  },
+  "homepage": "https://github.com/joewalnes/reconnecting-websocket"
+}


### PR DESCRIPTION
I'm using npm to manage all my javascript dependies (include client-side dependies via browserify), it requires `package.json` file in root folder of the repo.

Now anyone can install reconnection-websocket library just using `npm install joewalnes/reconnecting-websocket`
