### PR TITLE
Changed the connect method to a public API, so that a user can manually ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ With a `ReconnectingWebSocket`, after an `onclose` event is called it will autom
 
 This is all handled automatically for you by the library.
 
+Manually Opening, Closing and Refreshing connections
+----------------------------------------
+
+When you create a new `ReconnectingWebSocket`, the `WebSocket` connection is created and opened for you. In the case that you need to manually close a connection, simply run the `close()` method. To open the connection back up, use `open()`. If you need to close and immediately reopen the connection, use `refresh()`.
+
 More
 ----
 

--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -92,7 +92,7 @@
         this.onerror = function(event) {
         };
 
-        this.connect = function(reconnectAttempt) {
+        this.open = function(reconnectAttempt) {
             ws = new WebSocket(url, protocols);
 
             self.onconnecting();
@@ -138,7 +138,7 @@
                     }
                     setTimeout(function() {
                         self.reconnectAttempts++;
-                        self.connect(true);
+                        self.open(true);
                     }, self.reconnectInterval * Math.pow(self.reconnectDecay, self.reconnectAttempts));
                 }
             };
@@ -155,7 +155,7 @@
                 self.onerror(event);
             };
         }
-        this.connect(false);
+        this.open(false);
 
         this.send = function(data) {
             if (ws) {

--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -40,7 +40,7 @@
  *  onopen  // sometime later...
  *  onmessage
  *  onmessage
- *  etc... 
+ *  etc...
  *
  * It is API compatible with the standard WebSocket API.
  *
@@ -71,7 +71,7 @@
         var ws;
         var forcedClose = false;
         var timedOut = false;
-        
+
         this.url = url;
         this.protocols = protocols;
         this.readyState = WebSocket.CONNECTING;
@@ -92,14 +92,14 @@
         this.onerror = function(event) {
         };
 
-        function connect(reconnectAttempt) {
+        this.connect = function(reconnectAttempt) {
             ws = new WebSocket(url, protocols);
-            
+
             self.onconnecting();
             if (self.debug || ReconnectingWebSocket.debugAll) {
                 console.debug('ReconnectingWebSocket', 'attempt-connect', url);
             }
-            
+
             var localWs = ws;
             var timeout = setTimeout(function() {
                 if (self.debug || ReconnectingWebSocket.debugAll) {
@@ -109,7 +109,7 @@
                 localWs.close();
                 timedOut = false;
             }, self.timeoutInterval);
-            
+
             ws.onopen = function(event) {
                 clearTimeout(timeout);
                 if (self.debug || ReconnectingWebSocket.debugAll) {
@@ -120,7 +120,7 @@
                 self.reconnectAttempts = 0;
                 self.onopen(event);
             };
-            
+
             ws.onclose = function(event) {
                 clearTimeout(timeout);
                 ws = null;
@@ -138,7 +138,7 @@
                     }
                     setTimeout(function() {
                         self.reconnectAttempts++;
-                        connect(true);
+                        self.connect(true);
                     }, self.reconnectInterval * Math.pow(self.reconnectDecay, self.reconnectAttempts));
                 }
             };
@@ -155,7 +155,7 @@
                 self.onerror(event);
             };
         }
-        connect(false);
+        this.connect(false);
 
         this.send = function(data) {
             if (ws) {


### PR DESCRIPTION
...connect/reconnect. Refresh doesn't work if the user manually closed the connection, forcing the user to recreate the Reconnecting Websocket Object and redefine all methods for it. This pull request solves this problem.
