### PR TITLE
Tidy up events

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -217,11 +217,14 @@
                 ws = null;
                 if (forcedClose) {
                     self.readyState = WebSocket.CLOSED;
-                    self.onclose(event);
                     eventTarget.dispatchEvent(generateEvent('close'));
                 } else {
                     self.readyState = WebSocket.CONNECTING;
-                    eventTarget.dispatchEvent(generateEvent('connecting'));
+                    var e = generateEvent('connecting');
+                    e.code = event.code;
+                    e.reason = event.reason;
+                    e.wasClean = event.wasClean;
+                    eventTarget.dispatchEvent(e);
                     if (!reconnectAttempt && !timedOut) {
                         if (self.debug || ReconnectingWebSocket.debugAll) {
                             console.debug('ReconnectingWebSocket', 'onclose', url);
@@ -246,7 +249,7 @@
                 if (self.debug || ReconnectingWebSocket.debugAll) {
                     console.debug('ReconnectingWebSocket', 'onerror', url, event);
                 }
-                eventTarget.dispatchEvent(generateEvent('event'));
+                eventTarget.dispatchEvent(generateEvent('error'));
             };
         }
         connect(false);


### PR DESCRIPTION
1. Avoid generating two `onclose` calls on explicit `close()`.
2. On disconnect, make the close reason available to `onconnecting`.  (The first connect also fires `onconnecting`, and can be distinguished with `event.code !== undefined` or similar; alternately maybe this should be a "reconnecting" event only?)
3. Correct typo in generation of `error` event.

Note that having the close reasons on `onconnecting` instead of `onclose` means that it's not completely API compatible with `WebSocket`, but then it wasn't before either.
