### PR TITLE
Added automaticOpen option. Determines whether or not the socket will be...

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ or
 - Accepts `true` or `false`
 - Default value: `false`
 
+#### `automaticOpen`
+- Whether or not the websocket should attempt to connect immediately upon instantiation. The socket can be manually opened or closed at any time using ws.open() and ws.close().
+- Accepts `true` or `false`
+- Default value: `true`
+
 #### `reconnectInterval`
 - The number of milliseconds to delay before attempting to reconnect.
 - Accepts `integer`
@@ -94,6 +99,23 @@ or
 - Default: `2000`
 
 ---
+
+## Methods
+
+#### `ws.open()`
+- Open the Reconnecting Websocket
+
+#### `ws.close(code, reason)`
+- Closes the WebSocket connection or connection attempt, if any. If the connection is already CLOSED, this method does nothing.
+- `code` is optional the closing code (default value 1000). [https://tools.ietf.org/html/rfc6455#section-7.4.1](https://tools.ietf.org/html/rfc6455#section-7.4.1)
+- `reason` is the optional reason that the socket is being closed. [https://tools.ietf.org/html/rfc6455#section-7.1.6](https://tools.ietf.org/html/rfc6455#section-7.1.6)
+
+#### `ws.refresh()`
+- Refresh the connection if still open (close and then re-open it).
+
+#### `ws.send(data)`
+- Transmits data to the server over the WebSocket connection.
+- Accepts @param data a text string, ArrayBuffer or Blob
 
 Like this? Check out [websocketd](https://github.com/joewalnes/websocketd) for the simplest way to create WebSocket backends from any programming language.
 

--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -76,6 +76,9 @@
  * debug
  * - Whether this instance should log debug messages. Accepts true or false. Default: false.
  *
+ * automaticOpen
+ * - Whether or not the websocket should attempt to connect immediately upon instantiation. The socket can be manually opened or closed at any time using ws.open() and ws.close().
+ *
  * reconnectInterval
  * - The number of milliseconds to delay before attempting to reconnect. Accepts integer. Default: 1000.
  *


### PR DESCRIPTION
- Added `automaticOpen` (true/false) option. Determines whether or not the socket will be created and connect automatically upon instantiation or not.

- Also changed function `connect()` to publicly available `open()`. Now the user can manually `close()` and `open()` the connection if they desired to.

- Also changed the `open()` function to use `self.url` instead of `url`, allowing a user to change the `url` if they want. So a user could `close()`, then change the URL to another websocket URL, then `open()`. Ultimately a user would most likely just create a different ReconnectingWebSocket instance as that is a better solution and a better practice anyways, but this option was easy to add and probably a good idea to have in there now that a user can manually `open()` and `close()` the connection at will.

- Backwards compatibility is maintained with these changes, as `automaticOpen` is `true` by default which is the current behavior.