### PR TITLE
Fix incorrect bower package name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "reconnecting-websocket",
+  "name": "reconnectingWebsocket",
   "main": "reconnecting-websocket.js",
   "version": "0.0.0",
   "homepage": "https://github.com/joewalnes/reconnecting-websocket",


### PR DESCRIPTION
Existing "name" in bower.json points to wrong repository.  Doing a bower install failed.  
Doing a bower search pulls back the following results : 

bower search reconnecting-websocket
Search results:

    angular-reconnecting-websocket git://github.com/adieu/angular-reconnecting-websocket.git
    reconnectingWebsocket git://github.com/joewalnes/reconnecting-websocket.git
    reconnecting-websocket git://github.com/firstopinion/reconnecting-websocket.git