### PR TITLE
Add maxReconnectAttempts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ socket.timeoutInterval = 5400;
 - Accepts `integer`
 - Default: `2000`
 
+#### `maxReconnectAttempts`
+- The maximum number of reconnection attempts that will be made before giving up. If null, reconnection attempts will be continue to be made forever.
+- Accepts `integer` or `null`.
+- Default: `null`
+
 ---
 
 ## Methods

--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -201,12 +201,13 @@
         this.open = function (reconnectAttempt) {
             ws = new WebSocket(self.url, protocols || []);
 
-            if (!reconnectAttempt) {
+            if (reconnectAttempt) {
+                if (this.maxReconnectAttempts && this.reconnectAttempts > this.maxReconnectAttempts) {
+                    return;
+                }
+            } else {
                 eventTarget.dispatchEvent(generateEvent('connecting'));
-            }
-
-            if (this.maxReconnectAttempts && this.reconnectAttempts > this.maxReconnectAttempts) {
-                return;
+                this.reconnectAttempts = 0;
             }
 
             if (self.debug || ReconnectingWebSocket.debugAll) {

--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -122,6 +122,9 @@
 
             /** The maximum time in milliseconds to wait for a connection to succeed before closing and retrying. */
             timeoutInterval: 2000
+
+            /** The maximum number of reconnection attempts to make. Unlimited if null. */
+            maxReconnectAttempts: null,
         }
         if (!options) { options = {}; }
 
@@ -200,6 +203,10 @@
 
             if (!reconnectAttempt) {
                 eventTarget.dispatchEvent(generateEvent('connecting'));
+            }
+
+            if (this.maxReconnectAttempts && this.reconnectAttempts > this.maxReconnectAttempts) {
+                return;
             }
 
             if (self.debug || ReconnectingWebSocket.debugAll) {

--- a/reconnecting-websockets.d.ts
+++ b/reconnecting-websockets.d.ts
@@ -35,6 +35,9 @@ declare class ReconnectingWebSocket
     /** The maximum time in milliseconds to wait for a connection to succeed before closing and retrying. */
     public timeoutInterval: number;
 
+    /** The maximum number of reconnection attempts to make. Unlimited if null. */
+    public maxReconnectAttempts?: number;
+
     /** An event listener to be called when a connection begins being attempted. */
     onconnecting: (ev: Event) => any;
 


### PR DESCRIPTION
This pull request adds a `maxReconnectAttempts` option which controls the maximum number of reconnection attempts `ReconnectingWebSocket` will make before giving up.

This will allow users of this library to use short reconnection intervals without the risk of being smashed by potentially tens of thousands of clients trying to reconnect forever in case the WebSocket server goes down.