### PR TITLE
Feature detect WebSockets in older clients

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -102,6 +102,10 @@
     }
 })(this, function () {
 
+    if (!('WebSocket' in window)) {
+        return;
+    }
+
     function ReconnectingWebSocket(url, protocols, options) {
 
         // Default settings


### PR DESCRIPTION
It'd be nice to be able to load this script in older clients that don't support WebSockets like IE9.

I think it makes sense to just leave `ReconnectingWebSocket` `undefined` so you can feature check it in the same way.

So if you're code was

``` js
if ('WebSocket' in window) {
  var ws = new WebSocket('ws://....');
}
```

You can just change that to

``` js
if ('ReconnectingWebSocket' in window) {
  var ws = new ReconnectingWebSocket('ws://....');
}
```

/cc @joewalnes @mislav