### PR TITLE
Pull request for issue 53, do not reconnect when the connection was closed by the client

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -264,8 +264,10 @@
 
                     var timeout = self.reconnectInterval * Math.pow(self.reconnectDecay, self.reconnectAttempts);
                     setTimeout(function() {
-                        self.reconnectAttempts++;
-                        self.open(true);
+                    	if (!forcedClose) {
+	                        self.reconnectAttempts++;
+	                        self.open(true);
+                    	}
                     }, timeout > self.maxReconnectInterval ? self.maxReconnectInterval : timeout);
                 }
             };


### PR DESCRIPTION
My client checks the event code in onconnecting(evt), when this is not a network-error it will call close() on the reconnecting websocket.
The proposed fix then will stop reconnecting.
