### PR TITLE
Fix mixed indentation

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -200,9 +200,9 @@
          * @param args Object an optional object that the event will use
          */
         function generateEvent(s, args) {
-        	var evt = document.createEvent("CustomEvent");
-        	evt.initCustomEvent(s, false, false, args);
-        	return evt;
+            var evt = document.createEvent("CustomEvent");
+            evt.initCustomEvent(s, false, false, args);
+            return evt;
         };
 
         this.open = function (reconnectAttempt) {


### PR DESCRIPTION
All indentation uses spaces, instead of 3 lines, which use both tabs and spaces. I turned these tabs into spaces.