### PR TITLE
Fixed a spacing issue on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ socket.timeoutInterval = 5400;
 - Accepts `integer`
 - Default: `30000`
 
-####`reconnectDecay`
+#### `reconnectDecay`
 - The rate of increase of the reconnect delay. Allows reconnect attempts to back off when problems persist.
 - Accepts `integer` or `float`
 - Default: `1.5`


### PR DESCRIPTION
Very small fix. There was a missing space causing the heading to not show properly.