### PR TITLE
Reset `forcedClose` flag on socket open

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -208,6 +208,7 @@
         this.open = function (reconnectAttempt) {
             ws = new WebSocket(self.url, protocols || []);
             ws.binaryType = this.binaryType;
+            forcedClose = false;
 
             if (reconnectAttempt) {
                 if (this.maxReconnectAttempts && this.reconnectAttempts > this.maxReconnectAttempts) {


### PR DESCRIPTION
Client code may close and then open reconnectingwebsocket - in that
case `forcedClose` flag has to be reset, otherwise subsequent
disconnects would be treated as forced.