### PR TITLE
Timeout variable hoisting fix

### DIFF
--- a/reconnecting-websocket.js
+++ b/reconnecting-websocket.js
@@ -266,11 +266,11 @@
                         eventTarget.dispatchEvent(generateEvent('close'));
                     }
 
-                    var timeout = self.reconnectInterval * Math.pow(self.reconnectDecay, self.reconnectAttempts);
+                    var timeoutNumber = self.reconnectInterval * Math.pow(self.reconnectDecay, self.reconnectAttempts);
                     setTimeout(function() {
                         self.reconnectAttempts++;
                         self.open(true);
-                    }, timeout > self.maxReconnectInterval ? self.maxReconnectInterval : timeout);
+                    }, timeoutNumber > self.maxReconnectInterval ? self.maxReconnectInterval : timeoutNumber);
                 }
             };
             ws.onmessage = function(event) {


### PR DESCRIPTION
timeout variable is hoisting and replacing scope from the real timeout variable which we wanted to clearTimeout in ws.onclose